### PR TITLE
use latest version from logstore (compatible to streamr 1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 6. Deploy the demo schema
    ```bash
-   kwil-cli database deploy -p=./examples/demo-contract/demo.kf --name=demo --sync
+   ./.build/kwil-cli database deploy -p=./examples/demo-contract/demo.kf --name=demo --sync
     ```
 
 7. Publish a message to the stream
@@ -60,7 +60,7 @@
 
 8. (After 2 minutes) Call an action to get data from kwil node
     ```bash
-    kwil-cli database call -a=get_data -n=demo
+    ./.build/kwil-cli database call -a=get_data -n=demo
    ```
 
 Verify the output of the last command. It should return the messages you published in the stream.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - `Docker Compose` [Install Instructions](https://docs.docker.com/compose)
 - `streamr-cli` and basic knowledge of [how to use it](https://docs.streamr.network/usage/cli-tool).
   ```shell
-   pnpm install -g @streamr/cli-tools@8.5.5
+   pnpm install -g @streamr/cli-tools@latest
    ```
 - `kwil-cli`, `kwil-admin` and a basic knowledge of [how to use it](https://docs.kwil.com/docs/kwil-cli/installation)
   ```shell

--- a/docker-compose-testnet.yaml
+++ b/docker-compose-testnet.yaml
@@ -152,7 +152,7 @@ services:
         source: ./examples/testnet/node1/logstore-config.json
         target: /home/node/.logstore/config/default.json
         read_only: true
-      - type: volume
+      - type: bind
         source: ./examples/testnet/node1/
         target: /home/node/.logstore/data/
 
@@ -173,7 +173,7 @@ services:
         source: ./examples/testnet/node2/logstore-config.json
         target: /home/node/.logstore/config/default.json
         read_only: true
-      - type: volume
+      - type: bind
         source: ./examples/testnet/node3/
         target: /home/node/.logstore/data/
 
@@ -194,7 +194,7 @@ services:
         source: ./examples/testnet/node3/logstore-config.json
         target: /home/node/.logstore/config/default.json
         read_only: true
-      - type: volume
+      - type: bind
         source: ./examples/testnet/node2/
         target: /home/node/.logstore/data/
 

--- a/docker-compose-testnet.yaml
+++ b/docker-compose-testnet.yaml
@@ -138,7 +138,7 @@ services:
   logstore-node-1:
     container_name: logstore-node-1
     hostname: logstore-node-1
-    image: ghcr.io/usherlabs/logstore-node:develop
+    image: ghcr.io/usherlabs/logstore-node:latest
     command: [ "start-in-docker", "start" ]
     networks:
       - kwil-network
@@ -153,13 +153,13 @@ services:
         target: /home/node/.logstore/config/default.json
         read_only: true
       - type: volume
-        source: data-logstore-1
-        target: /home/node/.logstore/
+        source: ./examples/testnet/node1/
+        target: /home/node/.logstore/data/
 
   logstore-node-2:
     container_name: logstore-node-2
     hostname: logstore-node-2
-    image: ghcr.io/usherlabs/logstore-node:develop
+    image: ghcr.io/usherlabs/logstore-node:latest
     command: [ "start-in-docker", "start" ]
     networks:
       - kwil-network
@@ -174,13 +174,13 @@ services:
         target: /home/node/.logstore/config/default.json
         read_only: true
       - type: volume
-        source: data-logstore-2
-        target: /home/node/.logstore/
+        source: ./examples/testnet/node3/
+        target: /home/node/.logstore/data/
 
   logstore-node-3:
     container_name: logstore-node-3
     hostname: logstore-node-3
-    image: ghcr.io/usherlabs/logstore-node:develop
+    image: ghcr.io/usherlabs/logstore-node:latest
     command: [ "start-in-docker", "start" ]
     networks:
       - kwil-network
@@ -195,8 +195,8 @@ services:
         target: /home/node/.logstore/config/default.json
         read_only: true
       - type: volume
-        source: data-logstore-3
-        target: /home/node/.logstore/
+        source: ./examples/testnet/node2/
+        target: /home/node/.logstore/data/
 
 
 
@@ -211,6 +211,3 @@ volumes:
   data-kwil-postgres-1:
   data-kwil-postgres-2:
   data-kwil-postgres-3:
-  data-logstore-1:
-  data-logstore-2:
-  data-logstore-3:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
   logstore-node:
     container_name: logstore-node
     hostname: logstore-node
-    image: "ghcr.io/usherlabs/logstore-node:develop"
+    image: "ghcr.io/usherlabs/logstore-node:latest"
     command: [ "start-in-docker", "start" ]
     networks:
       - kwil-network
@@ -64,12 +64,12 @@ services:
         - SINK_STELLAR_WALLET_PRIVATE_KEY=SCMDRX7A7OVRPAGXLUVRNIYTWBLCS54OV7UH2TF5URSG4B4JQMUADCYU
     volumes:
       - type: bind
-        source: ./examples/logstore-config.json
+        source: ./examples/single-node/logstore-config.json
         target: /home/node/.logstore/config/default.json
         read_only: true
       - type: bind
-        source: logstore-data
-        target: /home/node/.logstore/
+        source: ./examples/single-node/
+        target: /home/node/.logstore/data/
 
 networks:
   kwil-network:
@@ -78,5 +78,3 @@ networks:
 volumes:
   data-kwil:
   data-kwil-postgres:
-  data-push-tsn-data:
-  logstore-data:

--- a/internal/extensions/listeners/logstore_listener/logstore_listener.go
+++ b/internal/extensions/listeners/logstore_listener/logstore_listener.go
@@ -85,7 +85,7 @@ func Start(ctx context.Context, service *common.Service, eventstore listeners.Ev
 		case <-time.After(5 * time.Second):
 			err = paginatedPoller.Run(ctx, service, eventstore)
 			if err != nil {
-				return fmt.Errorf("failed to run paginated poller: %w", err)
+				service.Logger.Warn(fmt.Sprintf("failed to run paginated poller: %v", err))
 			}
 		}
 	}

--- a/internal/extensions/listeners/logstore_listener/logstore_poller.go
+++ b/internal/extensions/listeners/logstore_listener/logstore_poller.go
@@ -47,7 +47,7 @@ func (l *LogStorePoller) GetData(from, to int64) (**ingest_resolution.LogStoreIn
 
 		ingestMessages = append(ingestMessages, ingest_resolution.LogStoreIngestMessage{
 			Content:   strContent,
-			Timestamp: uint(message.Metadata.Id.Timestamp),
+			Timestamp: uint(message.Timestamp),
 		})
 	}
 

--- a/internal/logstore_client/authentication.go
+++ b/internal/logstore_client/authentication.go
@@ -14,10 +14,9 @@ func createAuthHeader(signer auth.EthPersonalSigner) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	signatureStr := hexutil.Encode(passwordSignature.Signature)
+	signatureStr := base64.StdEncoding.EncodeToString(passwordSignature.Signature)
 
 	token := userStr + ":" + signatureStr
-
 	base64Token := base64.StdEncoding.EncodeToString([]byte(token))
 
 	return "basic " + base64Token, nil

--- a/internal/logstore_client/logstore_client.go
+++ b/internal/logstore_client/logstore_client.go
@@ -122,30 +122,6 @@ func (c *LogStoreClient) QueryRange(streamId string, from, to int64, partition i
 	return c.FetchMessages(req)
 }
 
-// {
-//    "messages": [
-//        {
-//            "streamId": "0xd37dc4d7e2c1bdf3edd89db0e505394ea69af43d/kwil-demo",
-//            "streamPartition": 0,
-//            "timestamp": 1717251456911,
-//            "sequenceNumber": 0,
-//            "publisherId": "0xd37dc4d7e2c1bdf3edd89db0e505394ea69af43d",
-//            "msgChainId": "SSMpFE1J9BcHiq5shY3Q",
-//            "messageType": 27,
-//            "contentType": 0,
-//            "encryptionType": 0,
-//            "content": 1,
-//            "signatureType": 1,
-//            "signature": "6e5bc0cbb8f8a6e3af351758e179f5073b15d7591ce5923f552727f4d076e53b1db46fd7c508f89a9c07c3b17612cc961ea5a46ba502bed0d5221c3da59282611c"
-//        }
-//    ],
-//    "metadata": {
-//        "hasNext": false,
-//        "totalMessages": 1,
-//        "type": "metadata"
-//    }
-//}
-
 type JSONStreamMessage struct {
 	StreamId        string      `json:"streamId"`
 	StreamPartition int         `json:"streamPartition"`

--- a/internal/logstore_client/logstore_client.go
+++ b/internal/logstore_client/logstore_client.go
@@ -73,7 +73,7 @@ func (c *LogStoreClient) GetFirstMessageTimestamp(streamId string) (int64, error
 		return 0, nil
 	}
 
-	return streamMessageResponse[0].Metadata.Id.Timestamp, nil
+	return streamMessageResponse[0].Timestamp, nil
 }
 
 func (c *LogStoreClient) GetLatestMessageTimestamp(streamId string) (int64, error) {
@@ -91,7 +91,11 @@ func (c *LogStoreClient) GetLatestMessageTimestamp(streamId string) (int64, erro
 
 	streamMessageResponse, err := c.FetchMessages(req)
 
-	return streamMessageResponse[0].Metadata.Id.Timestamp, nil
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch messages: %w", err)
+	}
+
+	return streamMessageResponse[0].Timestamp, nil
 }
 
 func (c *LogStoreClient) GetStreamPartitionCount(streamId string) (int, error) {
@@ -118,25 +122,43 @@ func (c *LogStoreClient) QueryRange(streamId string, from, to int64, partition i
 	return c.FetchMessages(req)
 }
 
+// {
+//    "messages": [
+//        {
+//            "streamId": "0xd37dc4d7e2c1bdf3edd89db0e505394ea69af43d/kwil-demo",
+//            "streamPartition": 0,
+//            "timestamp": 1717251456911,
+//            "sequenceNumber": 0,
+//            "publisherId": "0xd37dc4d7e2c1bdf3edd89db0e505394ea69af43d",
+//            "msgChainId": "SSMpFE1J9BcHiq5shY3Q",
+//            "messageType": 27,
+//            "contentType": 0,
+//            "encryptionType": 0,
+//            "content": 1,
+//            "signatureType": 1,
+//            "signature": "6e5bc0cbb8f8a6e3af351758e179f5073b15d7591ce5923f552727f4d076e53b1db46fd7c508f89a9c07c3b17612cc961ea5a46ba502bed0d5221c3da59282611c"
+//        }
+//    ],
+//    "metadata": {
+//        "hasNext": false,
+//        "totalMessages": 1,
+//        "type": "metadata"
+//    }
+//}
+
 type JSONStreamMessage struct {
-	Metadata struct {
-		Id struct {
-			StreamId        string `json:"streamId"`
-			StreamPartition int    `json:"streamPartition"`
-			Timestamp       int64  `json:"timestamp"`
-			SequenceNumber  int    `json:"sequenceNumber"`
-			PublisherId     string `json:"publisherId"`
-			MsgChainId      string `json:"msgChainId"`
-		} `json:"id"`
-		PrevMsgRef     interface{} `json:"prevMsgRef"`
-		MessageType    int         `json:"messageType"`
-		ContentType    int         `json:"contentType"`
-		EncryptionType int         `json:"encryptionType"`
-		GroupKeyId     interface{} `json:"groupKeyId"`
-		NewGroupKey    interface{} `json:"newGroupKey"`
-		Signature      string      `json:"signature"`
-	} `json:"metadata"`
-	Content interface{} `json:"content"`
+	StreamId        string      `json:"streamId"`
+	StreamPartition int         `json:"streamPartition"`
+	Timestamp       int64       `json:"timestamp"`
+	SequenceNumber  int         `json:"sequenceNumber"`
+	PublisherId     string      `json:"publisherId"`
+	MsgChainId      string      `json:"msgChainId"`
+	MessageType     int         `json:"messageType"`
+	ContentType     int         `json:"contentType"`
+	EncryptionType  int         `json:"encryptionType"`
+	Content         interface{} `json:"content"`
+	SignatureType   int         `json:"signatureType"`
+	Signature       string      `json:"signature"`
 }
 
 // create decoder from response body


### PR DESCRIPTION
- It isn't nearly instant anymore to start getting messages on the log store (I waited 8 minutes once). So, the Oracle can lose some messages if the log store responds that for that queried time, it's empty. Sometimes, it is faster, and on certain restarts, it works instantly again.
- Due to new permission errors, revert the behavior to bind to the host directory. I also tested by fresh cloning the repo and testing everything again to be sure I changed nothing on the permissions.
- change auth token creation 
- change messages payload
- include instructions to alternatively use the UI to create streams

tested using `Docker version 24.0.7` in Ubuntu 22.04 (x86_64)